### PR TITLE
Calculate mass mentions over a length of time (fixes #22)

### DIFF
--- a/src/commands/settings/settings.js
+++ b/src/commands/settings/settings.js
@@ -246,7 +246,7 @@ exports.mentions = {
             let num = Number(Math.abs(ctx.args[1]).toFixed(0));
 
             if (isNaN(num)) {
-                await ctx.createMesage('You can only set trigger to a valid number.');
+                await ctx.createMessage('You can only set trigger to a valid number.');
             } else if (num === 0) {
                 await ctx.createMessage('You cannot set trigger to 0. If you wish to disable mass mention blocking, run `settings mentions disable`.');
             } else {
@@ -257,7 +257,7 @@ exports.mentions = {
             let num = Number(Math.abs(ctx.args[1]).toFixed(0));
 
             if (isNaN(num)) {
-                await ctx.createMesage('You can only set timelimit to a valid number.');
+                await ctx.createMessage('You can only set timelimit to a valid number.');
             } else if (num < 1000) {
                 await ctx.createMessage('You cannot set timelimit to less than 1000ms. Remember that this value is in milliseconds, not seconds.');
             } else {
@@ -367,7 +367,7 @@ exports.diacritics = {
             let num = Number(Math.abs(ctx.args[1]).toFixed(0));
 
             if (isNaN(num)) {
-                await ctx.createMesage('You can only set trigger to a valid number.');
+                await ctx.createMessage('You can only set trigger to a valid number.');
             } else if (num === 0) {
                 await ctx.createMessage('You cannot set trigger to 0. If you wish to disable spammy diacritics blocking, run `settings diacritics disable`.');
             } else {
@@ -530,7 +530,7 @@ exports.exceptions = {
 
             await ctx.createMessage({embed});
         } else if (ctx.args[0] === 'users') {
-            if (!ctx.raw.split(' ').slice(2).join(' ')) return await ctx.createMesage(`Please give me a user to ${ctx.args[1]} an exception for.`);
+            if (!ctx.raw.split(' ').slice(2).join(' ')) return await ctx.createMessage(`Please give me a user to ${ctx.args[1]} an exception for.`);
 
             let user = await bot.lookups.memberLookup(ctx, ctx.raw.split(' ').slice(2).join(' '), false);
 
@@ -560,7 +560,7 @@ exports.exceptions = {
                 await ctx.createMessage("There isn't an exception for that user.");
             }
         } else if (ctx.args[0] === 'channels') {
-            if (!ctx.raw.split(' ').slice(2).join(' ')) return await ctx.createMesage(`Please give me a channel to ${ctx.args[1]} an exception for.`);
+            if (!ctx.raw.split(' ').slice(2).join(' ')) return await ctx.createMessage(`Please give me a channel to ${ctx.args[1]} an exception for.`);
 
             let channel = await bot.lookups.channelLookup(ctx, ctx.raw.split(' ').slice(2).join(' '));
 
@@ -585,7 +585,7 @@ exports.exceptions = {
                 await ctx.createMessage("There isn't an exception for that channel.");
             }
         } else if (ctx.args[0] === 'roles') {
-            if (!ctx.raw.split(' ').slice(2).join(' ')) return await ctx.createMesage('Please give me a role to add an exception for.');
+            if (!ctx.raw.split(' ').slice(2).join(' ')) return await ctx.createMessage('Please give me a role to add an exception for.');
 
             let role = await bot.lookups.roleLookup(ctx, ctx.raw.split(' ').slice(2).join(' '));
 

--- a/src/commands/settings/settings.js
+++ b/src/commands/settings/settings.js
@@ -186,13 +186,13 @@ exports.invites = {
 
 exports.mentions = {
     desc: 'Edit mass mention settings for the bot.',
-    usage: '[enable | disable | trigger <number> | kick <number> | ban <number>]',
+    usage: '[enable | disable | trigger <number> | timelimit <number> | kick <number> | ban <number>]',
     async main(bot, ctx) {
-        if (!['enable', 'disable', 'trigger', 'kick', 'ban'].includes(ctx.args[0])) {
+        if (!['enable', 'disable', 'trigger', 'timelimit', 'kick', 'ban'].includes(ctx.args[0])) {
             let embed = {
                 title: 'Server Settings - Mentions',
                 description: `Showing current mass-mention settings for **${ctx.guild.name}**.`,
-                footer: {text: "'Amount to Trigger' is how many mentions in one message or done fast enough is needed for the bot to be triggered."},
+                footer: {text: "'Amount to Trigger' is how many mentions in one message or done fast enough is needed for the bot to be triggered. 'Time Limit' is the time (in milliseconds) until mentions no longer count towards the 'Amount to Trigger'"},
                 fields: [
                     {
                         name: '`Status`',
@@ -204,6 +204,12 @@ exports.mentions = {
                         name: '`Amount to Trigger`',
                         value: `**${ctx.settings.mentions.trigger}**\n`
                         + 'Key: `trigger <number>`',
+                        inline: true
+                    },
+                    {
+                        name: '`Time Limit`',
+                        value: `**${ctx.settings.mentions.timelimit || 5000}ms**\n`
+                        + 'Key `timelimit <number>`',
                         inline: true
                     },
                     {
@@ -246,6 +252,17 @@ exports.mentions = {
             } else {
                 await bot.editSettings(ctx.guild.id, {mentions: {enabled: ctx.settings.mentions.enabled, trigger: num}});
                 await ctx.createMessage(`Set trigger limit to **${num}**.`);
+            }
+        } else if (ctx.args[0] === 'timelimit') {
+            let num = Number(Math.abs(ctx.args[1]).toFixed(0));
+
+            if (isNaN(num)) {
+                await ctx.createMesage('You can only set timelimit to a valid number.');
+            } else if (num < 1000) {
+                await ctx.createMessage('You cannot set timelimit to less than 1000ms. Remember that this value is in milliseconds, not seconds.');
+            } else {
+                await bot.editSettings(ctx.guild.id, {mentions: {enabled: ctx.settings.mentions.enabled, timelimit: num}});
+                await ctx.createMessage(`Set time limit to **${num}**.`);
             }
         } else if (ctx.args[0] === 'kick') {
             let num = Number(Math.abs(ctx.args[1]).toFixed(0));

--- a/src/events/moderation.js
+++ b/src/events/moderation.js
@@ -49,11 +49,13 @@ module.exports = bot => {
         let mentions = msg.mentions.filter(u => u.id !== msg.author.id && !u.bot);
 
         let trackerKey = msg.channel.guild.id + ':' + msg.author.id;
+
         if (mentionTracker[trackerKey]) {
             mentionTracker[trackerKey] += mentions.length;
         } else {
             mentionTracker[trackerKey] = mentions.length;
         }
+
         setTimeout(() => {
             if (mentionTracker[trackerKey] <= mentions.length) {
                 delete mentionTracker[trackerKey];

--- a/src/events/moderation.js
+++ b/src/events/moderation.js
@@ -15,7 +15,7 @@ module.exports = bot => {
         try {
             let invCode = msg.content.match(InviteRegex)[1];
             let inv = await bot.getInvite(invCode);
-            
+
             if (inv.guild.id === msg.channel.guild.id) return;
 
             await msg.delete();
@@ -36,6 +36,8 @@ module.exports = bot => {
         }
     });
 
+    let mentionTracker = {};
+
     bot.on('mentions', async msg => {
         if (!bot.hasWantedPerms(msg) || msg.author.id === msg.channel.guild.ownerID) return;
 
@@ -46,7 +48,21 @@ module.exports = bot => {
 
         let mentions = msg.mentions.filter(u => u.id !== msg.author.id && !u.bot);
 
-        if (mentions.length >= settings.mentions.trigger) {
+        let trackerKey = msg.channel.guild.id + ':' + msg.author.id;
+        if (mentionTracker[trackerKey]) {
+            mentionTracker[trackerKey] += mentions.length;
+        } else {
+            mentionTracker[trackerKey] = mentions.length;
+        }
+        setTimeout(() => {
+            if (mentionTracker[trackerKey] <= mentions.length) {
+                delete mentionTracker[trackerKey];
+            } else {
+                mentionTracker[trackerKey] -= mentions.length;
+            }
+        }, settings.mentions.timelimit || 5000);
+
+        if (mentionTracker[trackerKey] >= settings.mentions.trigger) {
             try {
                 await msg.delete();
                 await punishChain(bot, msg, settings, 'mentions', `(${mentions.length} mentions)`);
@@ -119,7 +135,7 @@ async function punishChain(bot, msg, settings, type, extra) {
 
     if (settings.actions[type].kick > 0 && strikes === settings.actions[type].kick) {
         await msg.member.kick(type);
-        
+
         bot.emit('log', {
             user: msg.author,
             action: 0,

--- a/src/modules/extensions.js
+++ b/src/modules/extensions.js
@@ -20,7 +20,7 @@ module.exports = bot => {
 
     /**
      * Easily format a username.
-     * 
+     *
      * @param {(Eris.Member|Eris.User)} user The user to format. If a member is passed, will use their nickname if possible.
      * @returns {?String} The formatted string. Null if proper user isnt passed.
      */
@@ -30,7 +30,7 @@ module.exports = bot => {
 
     /**
      * Wait for a message in a channel from a user.
-     * 
+     *
      * @param {String} channelID The ID of the channel
      * @param {Sting} userID The ID of the user
      * @param {Function} [filter] Optional filter function that returns a boolean when passed a Message object
@@ -56,7 +56,7 @@ module.exports = bot => {
                     bot.removeListener('messageCreate', onCrtWrap);
                     clearInterval(rmvTimeout);
                     resolve(res);
-                } 
+                }
             };
 
             bot.on('messageCreate', onCrtWrap);
@@ -87,7 +87,7 @@ module.exports = bot => {
 
     /**
      * Returns a random game from the games array
-     * 
+     *
      * @returns {String} The game.
      */
     bot.pickGame = () => {
@@ -114,7 +114,7 @@ module.exports = bot => {
 
     /**
      * Initialises settings for a guild in the database.
-     * 
+     *
      * @param {String} guildID The ID of the guild
      * @returns {Promise<Object>} Settings for the guild.
      */
@@ -124,7 +124,7 @@ module.exports = bot => {
         let settings = {
             id: guildID,
             actions: {mentions: {kick: 2, ban: 3}, invites: {kick: 2, ban: 3}, diacritics: {kick: 2, ban: 3}},
-            mentions: {trigger: 5, enabled: false},
+            mentions: {trigger: 5, enabled: false, timelimit: 5000},
             invites: {enabled: false, fake: false},
             diacritics: {trigger: 10, enabled: false},
             logChannel: null,
@@ -141,7 +141,7 @@ module.exports = bot => {
         };
 
         bot.settings.add(settings);
-        
+
         let res = await bot.db.table('guild_settings').get(guildID).run();
 
         if (res) return res;
@@ -150,7 +150,7 @@ module.exports = bot => {
 
     /**
      * Gets settings for a guild.
-     * 
+     *
      * @param {String} guildID The ID of the guild
      * @returns {Promise<Object>} Settings for the guild.
      */
@@ -170,7 +170,7 @@ module.exports = bot => {
 
     /**
      * Edits settings for a guild.
-     * 
+     *
      * @param {String} guildID The ID of the guild
      * @param {Object} settings The settings to edit
      * @returns {Promise<Object>} Settings for the guild.
@@ -195,7 +195,7 @@ module.exports = bot => {
 
     /**
      * Get strikes for a user or guild.
-     * 
+     *
      * @param {String} guildID ID of the guild to find strikes for.
      * @param {String} [userID] ID of the user to get strikes for.
      * @returns {Promise<(Number|Object[])>} Strikes for the guild or user.
@@ -218,9 +218,9 @@ module.exports = bot => {
         }
     };
 
-    /** 
+    /**
      * Increment someones strike count.
-     * 
+     *
      * @param {String} guildID ID of the guild.
      * @param {String} userID ID of the user.
      */
@@ -251,7 +251,7 @@ module.exports = bot => {
 
     /**
      * Decrement someones strike count.
-     * 
+     *
      * @param {String} guildID ID of the guild.
      * @param {String} userID ID of the user.
      */
@@ -282,7 +282,7 @@ module.exports = bot => {
 
     /**
      * Reset someones strike count.
-     * 
+     *
      * @param {String} guildID ID of the guild.
      * @param {String} userID ID of the user.
      */
@@ -311,7 +311,7 @@ module.exports = bot => {
 
     /**
      * POST something to Hastebin.
-     * 
+     *
      * @param {String} str Content to POST.
      * @returns {String} Returned key.
      */
@@ -328,7 +328,7 @@ module.exports = bot => {
 
     /**
      * Check if a user is blacklisted.
-     * 
+     *
      * @param {String} userID ID of the user to check.
      * @returns {Boolean} If the user is blacklisted
      */
@@ -338,7 +338,7 @@ module.exports = bot => {
 
     /**
      * Check if a user is the bot owner.
-     * 
+     *
      * @param {String} userID ID of the user to check.
      * @returns {Boolean} If the user is the bot owner or not.
      */
@@ -348,7 +348,7 @@ module.exports = bot => {
 
     /**
      * Check if the bot has the perms wanted to work properly.
-     * 
+     *
      * @param {Eris.Message} msg Message to use.
      * @returns {Boolean} If the bot has the wanted perms or not.
     */
@@ -359,7 +359,7 @@ module.exports = bot => {
 
     /**
      * Check if a user is what appears to be a moderator.
-     * 
+     *
      * @param {Eris.Member} member Member to check.
      * @returns {Boolean} If the member seems to be a moderator or not.
      */


### PR DESCRIPTION
Mention counts are now tracked in guild + author pairs. The time limit before mentions are no longer counted is configurable through a new config option (`mentions.timelimit`). Wording is a bit iffy ¯\\\_(ツ)_/¯

Also lol `ctx.createMesage`